### PR TITLE
Removed Duration Check on Auras in Specific Spells List

### DIFF
--- a/PlateBuffs/core.lua
+++ b/PlateBuffs/core.lua
@@ -522,7 +522,7 @@ do
 				name, _, icon, count, _, duration, expirationTime, unitCaster, _, _, spellId = UnitBuff(unitID, i)
 				icon = icon:upper():gsub("(.+)\\(.+)\\", "")
 
-				local spellOpts = (duration > 0) and self:HaveSpellOpts(name, spellId) or nil
+				local spellOpts = self:HaveSpellOpts(name, spellId)
 				if spellOpts and spellOpts.show and P.defaultBuffShow ~= 4 then
 					if
 						spellOpts.show == 1 or

--- a/PlateBuffs/core.lua
+++ b/PlateBuffs/core.lua
@@ -570,7 +570,7 @@ do
 				name, _, icon, count, debuffType, duration, expirationTime, unitCaster, _, _, spellId = UnitDebuff(unitID, i)
 				icon = icon:upper():gsub("INTERFACE\\ICONS\\", "")
 
-				local spellOpts = (duration > 0) and self:HaveSpellOpts(name, spellId) or nil
+				local spellOpts = self:HaveSpellOpts(name, spellId)
 				if spellOpts and spellOpts.show and P.defaultDebuffShow ~= 4 then
 					if
 						spellOpts.show == 1 or


### PR DESCRIPTION
This was causing issues with e.g., Grounding Totem Effect never showing up because its duration was 0 (endless), even though it was added to the list in Specific Spells.

This fix removes the duration > 0 check for auras which are in the Specific Spells list (but still keeps it for all other auras).