### PR TITLE
Fixed Cooldown Texture Not Fading Correctly

### DIFF
--- a/PlateBuffs/frames.lua
+++ b/PlateBuffs/frames.lua
@@ -320,7 +320,9 @@ local function iconOnUpdate(self, elapsed)
 					self.cd2:SetTextColor(core:RedToGreen(timeLeft, self.duration))
 				end
 				if not self.cdtexture.SetCooldown then
-					self.cdtexture:SetHeight(max(0.00001, ((self.duration - timeLeft) / self.duration) * P.iconSize2))
+					local currRatio = 1 - rawTimeLeft / self.duration
+					local currSize = currRatio * self.icon:GetHeight()
+					self.cdtexture:SetHeight(max(0.00001, currSize))
 				end
 			end
 


### PR DESCRIPTION
Fixed up some issues with the cooldown "spiral" (texture, not really a spiral) that could occur based on config options made. See example here:

![image](https://github.com/bkader/PlateBuffs_WoTLK/assets/16864855/3e60cea4-ced0-445a-ab37-3546c454cfc1)

Also made it slightly more responsive by using rawTimeLeft.